### PR TITLE
feat: per-user agent concurrency limits — Settings UI + API

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1843,7 +1843,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2213,7 +2212,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/client/src/pages/SettingsPage.jsx
+++ b/client/src/pages/SettingsPage.jsx
@@ -1,6 +1,6 @@
 import { authedFetch } from "../lib/api.js";
-import { useState } from "react";
-import { Settings, Zap, Hand, Info, Database, KeyRound, RotateCcw, CheckCircle, AlertCircle } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Settings, Zap, Hand, Info, Database, KeyRound, RotateCcw, CheckCircle, AlertCircle, Gauge, Lock, Users } from "lucide-react";
 
 const DEPLOYMENT_RULES = [
   {
@@ -246,6 +246,283 @@ function TokenRotationSection() {
   );
 }
 
+function ConcurrencyLimitsSection() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [globalLimit, setGlobalLimit] = useState(2);
+  const [agentLimits, setAgentLimits] = useState({});
+  const [agentUsage, setAgentUsage] = useState({});
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [toast, setToast] = useState(null); // { type: "success"|"error", message }
+
+  useEffect(() => {
+    authedFetch("/api/settings/concurrency")
+      .then(r => r.json())
+      .then(data => {
+        setGlobalLimit(data.global_user_concurrency_limit ?? 2);
+        setAgentLimits(data.agent_user_concurrency_limits ?? {});
+        setAgentUsage(data.agent_usage ?? {});
+        setIsAdmin(data.is_admin ?? false);
+        setLoading(false);
+      })
+      .catch(e => {
+        setToast({ type: "error", message: "Failed to load concurrency config: " + e.message });
+        setLoading(false);
+      });
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setToast(null);
+    try {
+      const resp = await authedFetch("/api/settings/concurrency", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          global_user_concurrency_limit: globalLimit,
+          agent_user_concurrency_limits: agentLimits,
+        }),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || "Request failed");
+      setToast({ type: "success", message: data.message || "Concurrency limits saved!" });
+    } catch (e) {
+      setToast({ type: "error", message: e.message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const agentNames = Object.keys(agentLimits);
+
+  const formatUsage = (agent) => {
+    const usage = agentUsage[agent] || {};
+    const entries = Object.entries(usage);
+    if (entries.length === 0) return "—";
+    return entries.map(([user, count]) => {
+      const display = user.length > 20 ? user.slice(0, 8) + "…" : user;
+      return `${display}: ${count}`;
+    }).join(", ");
+  };
+
+  return (
+    <div style={{
+      background: "var(--md-surface)",
+      borderRadius: 16,
+      border: "1px solid var(--md-surface-variant)",
+      overflow: "hidden",
+      marginBottom: 20,
+    }}>
+      {/* Header */}
+      <div style={{
+        padding: "16px 20px",
+        borderBottom: "1px solid var(--md-surface-variant)",
+        display: "flex", alignItems: "center", gap: 10,
+      }}>
+        <Gauge size={16} style={{ color: "var(--md-primary)" }} />
+        <div>
+          <div style={{ fontWeight: 600, fontSize: 15 }}>🔒 Agent Concurrency Limits</div>
+          <div style={{ fontSize: 12, color: "var(--md-on-surface-variant)", marginTop: 1 }}>
+            Configure how many tasks each user can run concurrently per agent
+          </div>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div style={{ padding: "20px" }}>
+        {loading ? (
+          <div style={{ display: "flex", alignItems: "center", gap: 10, color: "var(--md-on-surface-variant)", fontSize: 13 }}>
+            <div style={{
+              width: 16, height: 16, borderRadius: "50%",
+              border: "2px solid var(--md-primary)", borderTopColor: "transparent",
+              animation: "spin 0.7s linear infinite",
+            }} />
+            Loading concurrency config…
+          </div>
+        ) : (
+          <>
+            {/* Global Limit */}
+            <div style={{ marginBottom: 20 }}>
+              <label style={{
+                display: "flex", alignItems: "center", gap: 6,
+                fontSize: 12, fontWeight: 600,
+                color: "var(--md-on-surface-variant)",
+                textTransform: "uppercase", letterSpacing: "0.5px",
+                marginBottom: 8,
+              }}>
+                <Users size={13} />
+                Global User Concurrency Limit
+                {!isAdmin && <Lock size={12} style={{ marginLeft: 4, opacity: 0.6 }} />}
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={globalLimit}
+                disabled={!isAdmin}
+                onChange={e => setGlobalLimit(Number(e.target.value))}
+                style={{
+                  width: 100,
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  border: "1px solid var(--md-surface-variant)",
+                  background: isAdmin ? "var(--md-background)" : "var(--md-surface-variant)",
+                  color: "var(--md-on-surface)",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  outline: "none",
+                  opacity: isAdmin ? 1 : 0.7,
+                  cursor: isAdmin ? "auto" : "not-allowed",
+                }}
+              />
+              <span style={{ marginLeft: 10, fontSize: 12, color: "var(--md-on-surface-variant)" }}>
+                tasks per user across all agents
+              </span>
+            </div>
+
+            {/* Per-agent table */}
+            {agentNames.length > 0 && (
+              <div style={{ marginBottom: 20 }}>
+                <div style={{
+                  fontSize: 12, fontWeight: 600,
+                  color: "var(--md-on-surface-variant)",
+                  textTransform: "uppercase", letterSpacing: "0.5px",
+                  marginBottom: 10,
+                }}>
+                  Per-Agent Limits
+                  {!isAdmin && <Lock size={12} style={{ marginLeft: 6, opacity: 0.6 }} />}
+                </div>
+                <div style={{ overflowX: "auto" }}>
+                  <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+                    <thead>
+                      <tr style={{ background: "var(--md-surface-variant)" }}>
+                        {["Agent", "Limit per User", "Current Usage"].map(h => (
+                          <th key={h} style={{
+                            padding: "8px 14px",
+                            textAlign: "left",
+                            fontWeight: 600,
+                            fontSize: 11,
+                            textTransform: "uppercase",
+                            letterSpacing: "0.5px",
+                            color: "var(--md-on-surface-variant)",
+                            whiteSpace: "nowrap",
+                          }}>{h}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {agentNames.map((agent, i) => (
+                        <tr key={agent} style={{
+                          borderBottom: i < agentNames.length - 1
+                            ? "1px solid var(--md-surface-variant)"
+                            : "none",
+                        }}>
+                          <td style={{ padding: "10px 14px", fontFamily: "'JetBrains Mono', monospace", fontSize: 12, fontWeight: 600 }}>
+                            {agent}
+                          </td>
+                          <td style={{ padding: "10px 14px" }}>
+                            <input
+                              type="number"
+                              min={1}
+                              max={20}
+                              value={agentLimits[agent] ?? 1}
+                              disabled={!isAdmin}
+                              onChange={e => setAgentLimits(prev => ({ ...prev, [agent]: Number(e.target.value) }))}
+                              style={{
+                                width: 70,
+                                padding: "5px 10px",
+                                borderRadius: 6,
+                                border: "1px solid var(--md-surface-variant)",
+                                background: isAdmin ? "var(--md-background)" : "var(--md-surface-variant)",
+                                color: "var(--md-on-surface)",
+                                fontSize: 13,
+                                fontWeight: 600,
+                                outline: "none",
+                                opacity: isAdmin ? 1 : 0.7,
+                                cursor: isAdmin ? "auto" : "not-allowed",
+                              }}
+                            />
+                          </td>
+                          <td style={{ padding: "10px 14px", fontSize: 12, color: "var(--md-on-surface-variant)", fontFamily: "'JetBrains Mono', monospace" }}>
+                            {formatUsage(agent)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {/* Save button (admin only) */}
+            {isAdmin && (
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "10px 20px",
+                  borderRadius: 10,
+                  border: "none",
+                  background: saving ? "var(--md-surface-variant)" : "var(--md-primary)",
+                  color: saving ? "var(--md-on-surface-variant)" : "var(--md-on-primary)",
+                  fontWeight: 600,
+                  fontSize: 13,
+                  cursor: saving ? "not-allowed" : "pointer",
+                  transition: "background 0.15s",
+                  marginBottom: toast ? 14 : 0,
+                }}
+              >
+                <Gauge size={14} style={{ animation: saving ? "spin 1s linear infinite" : "none" }} />
+                {saving ? "Saving…" : "Save Concurrency Limits"}
+              </button>
+            )}
+
+            {/* Toast */}
+            {toast && (
+              <div style={{
+                marginTop: isAdmin ? 14 : 0,
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 8,
+                padding: "10px 14px",
+                borderRadius: 10,
+                background: toast.type === "success" ? "rgba(22,163,74,0.1)" : "rgba(220,38,38,0.1)",
+                border: `1px solid ${toast.type === "success" ? "rgba(22,163,74,0.25)" : "rgba(220,38,38,0.25)"}`,
+                color: toast.type === "success" ? "#16a34a" : "#dc2626",
+                fontSize: 13,
+              }}>
+                {toast.type === "success"
+                  ? <CheckCircle size={15} style={{ flexShrink: 0, marginTop: 1 }} />
+                  : <AlertCircle size={15} style={{ flexShrink: 0, marginTop: 1 }} />
+                }
+                <span style={{ fontWeight: 500 }}>{toast.message}</span>
+              </div>
+            )}
+
+            {!isAdmin && (
+              <div style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                fontSize: 12,
+                color: "var(--md-on-surface-variant)",
+                marginTop: 4,
+                opacity: 0.7,
+              }}>
+                <Lock size={12} />
+                Read-only — only admins can modify concurrency limits
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   return (
     <div style={{
@@ -357,6 +634,8 @@ export default function SettingsPage() {
         </div>
 
         <TokenRotationSection />
+
+        <ConcurrencyLimitsSection />
 
         {/* Future notice */}
         <div style={{

--- a/migrations/0028_dispatcher_config.sql
+++ b/migrations/0028_dispatcher_config.sql
@@ -1,0 +1,33 @@
+-- idempotent
+CREATE TABLE IF NOT EXISTS dispatcher_config (
+  key TEXT PRIMARY KEY,
+  value JSONB NOT NULL DEFAULT '{}',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by TEXT
+);
+
+-- Enable RLS
+ALTER TABLE dispatcher_config ENABLE ROW LEVEL SECURITY;
+
+-- Read for all authenticated users
+DO $$ BEGIN
+  CREATE POLICY "dispatcher_config_read" ON dispatcher_config
+    FOR SELECT TO authenticated USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Write only for admin
+DO $$ BEGIN
+  CREATE POLICY "dispatcher_config_write" ON dispatcher_config
+    FOR ALL TO authenticated
+    USING (auth.jwt() ->> 'email' = 'dante.perea@unifounder.ai')
+    WITH CHECK (auth.jwt() ->> 'email' = 'dante.perea@unifounder.ai');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Seed defaults
+INSERT INTO dispatcher_config (key, value, updated_by)
+VALUES 
+  ('global_user_concurrency_limit', '2'::jsonb, 'system'),
+  ('agent_user_concurrency_limits', '{"neo-worker": 1, "beta-worker": 1, "ifra-worker": 1, "research-worker": 1, "setup-agent": 1}'::jsonb, 'system')
+ON CONFLICT (key) DO NOTHING;

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -153,3 +153,115 @@ router.post("/rotate-claude-token", async (req, res) => {
     res.status(500).json({ error: e.message });
   }
 });
+
+// GET /api/settings/concurrency
+// Returns dispatcher_config limits + current per-agent per-user in-progress usage
+router.get("/concurrency", async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ error: "Authentication required" });
+    }
+
+    // Fetch all dispatcher_config rows
+    const { data: configRows, error: configErr } = await supabase
+      .from("dispatcher_config")
+      .select("key, value");
+
+    if (configErr) {
+      console.error("[settings] concurrency config fetch error:", configErr.message);
+      return res.status(500).json({ error: configErr.message });
+    }
+
+    const configMap = {};
+    for (const row of configRows || []) {
+      configMap[row.key] = row.value;
+    }
+
+    const global_user_concurrency_limit = configMap["global_user_concurrency_limit"] ?? 2;
+    const agent_user_concurrency_limits = configMap["agent_user_concurrency_limits"] ?? {};
+
+    // Fetch in-progress tasks to build usage map
+    const { data: inProgressTasks, error: tasksErr } = await supabase
+      .from("agent_tasks")
+      .select("assigned_agent, created_by")
+      .eq("status", "in_progress");
+
+    if (tasksErr) {
+      console.error("[settings] concurrency tasks fetch error:", tasksErr.message);
+      return res.status(500).json({ error: tasksErr.message });
+    }
+
+    // Build: { "neo-worker": { "user_id": count } }
+    const agent_usage = {};
+    for (const task of inProgressTasks || []) {
+      const agent = task.assigned_agent;
+      const user = task.created_by;
+      if (!agent || !user) continue;
+      if (!agent_usage[agent]) agent_usage[agent] = {};
+      agent_usage[agent][user] = (agent_usage[agent][user] || 0) + 1;
+    }
+
+    const is_admin = req.user?.email === "dante.perea@unifounder.ai";
+
+    res.json({
+      global_user_concurrency_limit,
+      agent_user_concurrency_limits,
+      agent_usage,
+      is_admin,
+    });
+  } catch (e) {
+    console.error("[settings] concurrency GET error:", e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// PUT /api/settings/concurrency
+// Update concurrency limits (admin only)
+router.put("/concurrency", async (req, res) => {
+  try {
+    if (!req.user || req.user.email !== "dante.perea@unifounder.ai") {
+      return res.status(403).json({ error: "Admin access required" });
+    }
+
+    const { global_user_concurrency_limit, agent_user_concurrency_limits } = req.body;
+
+    const upserts = [];
+
+    if (global_user_concurrency_limit !== undefined) {
+      upserts.push({
+        key: "global_user_concurrency_limit",
+        value: Number(global_user_concurrency_limit),
+        updated_at: new Date().toISOString(),
+        updated_by: req.user.email,
+      });
+    }
+
+    if (agent_user_concurrency_limits !== undefined) {
+      upserts.push({
+        key: "agent_user_concurrency_limits",
+        value: agent_user_concurrency_limits,
+        updated_at: new Date().toISOString(),
+        updated_by: req.user.email,
+      });
+    }
+
+    if (upserts.length === 0) {
+      return res.status(400).json({ error: "Nothing to update" });
+    }
+
+    const { error: upsertErr } = await supabase
+      .from("dispatcher_config")
+      .upsert(upserts, { onConflict: "key" });
+
+    if (upsertErr) {
+      console.error("[settings] concurrency upsert error:", upsertErr.message);
+      return res.status(500).json({ error: upsertErr.message });
+    }
+
+    console.log(`[settings] Concurrency limits updated by ${req.user.email}`);
+    res.json({ success: true, message: "Concurrency limits updated" });
+  } catch (e) {
+    console.error("[settings] concurrency PUT error:", e.message);
+    res.status(500).json({ error: e.message });
+  }
+});


### PR DESCRIPTION
## Task: b17f9e59-a098-4723-8298-ffdaa7c4442a

## Summary
Implements the admin-controlled per-user agent concurrency limits feature in the Settings page.

### Changes
- **`migrations/0028_dispatcher_config.sql`** — New `dispatcher_config` table with RLS (read for all authenticated, write for admin only). Seeds defaults: global limit=2, per-agent limit=1 for neo/beta/ifra/research/setup workers.
- **`server/routes/settings.js`** — Two new endpoints:
  - `GET /api/settings/concurrency` — returns config + live agent usage (in-progress tasks per user/agent)
  - `PUT /api/settings/concurrency` — admin-only upsert of limits
- **`client/src/pages/SettingsPage.jsx`** — New `ConcurrencyLimitsSection` component:
  - Global limit input + per-agent table with live usage display
  - Read-only for non-admins (lock icon shown), editable for `dante.perea@unifounder.ai`
  - Save button with success/error feedback

### Testing Notes
- Visit /settings as admin → should see concurrency card with editable inputs
- Visit /settings as non-admin → inputs locked with lock icon
- PUT /api/settings/concurrency as non-admin → 403
- DB migration has been executed (table live in lessxkxujvcmublgwdaa)

### Acceptance Criteria Met
- ✅ Settings UI shows global + per-agent concurrency limits
- ✅ Limits persist to Supabase (dispatcher_config table)
- ✅ Admin-only edit access